### PR TITLE
Filebeat output compression level must be between 1 and 9.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class logshipping (
     outputs       => {
       'logstash' =>  {
         'hosts'             => [ "localhost:${logzoom_listen_port}" ],
-        'compression_level' =>  0,
+        'compression_level' =>  1,
         'ssl.enabled'       => false,
       }
     }


### PR DESCRIPTION
Per the filebeat docs, compression level has to be between 1 and 9.  Setting
to 1 resolves the issue we were seeing in our test setup.
https://www.elastic.co/guide/en/beats/filebeat/current/logstash-output.html#_literal_compression_level_literal_2