### PR TITLE
Change Logzoom default output to JSON format

### DIFF
--- a/templates/logzoom.yaml.erb
+++ b/templates/logzoom.yaml.erb
@@ -13,6 +13,7 @@ outputs:
         s3_path: "<%= scope['::logshipping::output_s3_prefix'] %>"
         time_slice_format: "%Y/%m/%d/%H%M"
         aws_s3_output_key: "%{path}/%{timeSlice}/%{hostname}_%{uuid}.gz"
+        output_format: json
 
 routes:
   - route1:


### PR DESCRIPTION
This tells Logzoom to output as JSON so it includes all the tags and custom fields we're setting with Filebeat.  Requires https://github.com/claranet/logzoom/pull/1 to be merged into Logzoom first.