### PR TITLE
Allow changing the default S3 object ACL in Logzoom

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,6 +47,7 @@ classes:
 
 logshipping::output_s3_bucket: customername-logshipping
 logshipping::output_s3_prefix: "%{::envname}-${::envtype}"
+logshipping::output_s3_acl: bucket-owner-full-control
 logshipping::journalbeat_fields:
   account_name: "%{::account_name}" # Assumes we have a custom account_name fact
   envtype: "%{::envtype}" # Assumes we have a custom envtype fact

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class logshipping (
   String $output_s3_region = 'eu-west-1',
   String $output_s3_bucket = undef,
   String $output_s3_prefix = undef,
+  String $output_s3_acl = 'private',
 ){
 
   # validate parameters here

--- a/templates/logzoom.yaml.erb
+++ b/templates/logzoom.yaml.erb
@@ -13,6 +13,7 @@ outputs:
         s3_path: "<%= scope['::logshipping::output_s3_prefix'] %>"
         time_slice_format: "%Y/%m/%d/%H%M"
         aws_s3_output_key: "%{path}/%{timeSlice}/%{hostname}_%{uuid}.gz"
+        aws_s3_output_acl: "<%= scope['::logshipping::output_s3_acl'] %>"
         output_format: json
 
 routes:


### PR DESCRIPTION
By default, S3 sets the ACL to `private`, which makes the logs unreadable if the bucket is in a different account.

This PR adds the option to change the ACL set by Logzoom.