### PR TITLE
Update version of Filebeat Puppet module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "pcfens/filebeat",
-      "version_requirement": ">= 2.4.0"
+      "version_requirement": ">= 3.4.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The version of the filebeat module we currently use tries to use a deprecated `--configtest` function which causes Puppet failures on newer Filebeat versions.

Updating the Filebeat module fixes this.  I've tested this on a customer infrastructure and found no breaking issues.  From the changelog for the module, the only breaking change is that it defaults to Filebeat 6, which is fine as it's what we use everywhere this module is used.
https://github.com/pcfens/puppet-filebeat/blob/master/CHANGELOG.md